### PR TITLE
Repro to demo suggested solution doesn't work

### DIFF
--- a/PrismPopup/PrismPopup/PrismPopup/App.xaml.cs
+++ b/PrismPopup/PrismPopup/PrismPopup/App.xaml.cs
@@ -28,8 +28,9 @@ namespace PrismPopup
         {
             InitializeComponent();
             var cultureInfo = CultureInfo.GetCultureInfo("ar");
-          //  this.Culture = cultureInfo;
-            await NavigationService.NavigateAsync("NavigationPage/MenuPage");
+          //this.Culture = cultureInfo;
+          //await NavigationService.NavigateAsync("NavigationPage/MenuPage");
+            await NavigationService.NavigateAsync("PrismPopupMasterDetailPage/NavigationPage/MainPage");
         }
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry)
@@ -39,7 +40,8 @@ namespace PrismPopup
             containerRegistry.RegisterForNavigation<NavigationPage>();
             containerRegistry.RegisterForNavigation<MenuPage, MenuPageViewModel>();
             containerRegistry.RegisterForNavigation<MainPage, MainPageViewModel>();
-            
+            containerRegistry.RegisterForNavigation<PrismPopupMasterDetailPage, PrismPopupMasterDetailPageViewModel>();
+
         }
     }
 }

--- a/PrismPopup/PrismPopup/PrismPopup/ViewModels/PrismPopupMasterDetailPageViewModel.cs
+++ b/PrismPopup/PrismPopup/PrismPopup/ViewModels/PrismPopupMasterDetailPageViewModel.cs
@@ -1,0 +1,58 @@
+﻿using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Navigation;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xamarin.Forms;
+
+namespace PrismPopup.ViewModels
+{
+    public class PrismPopupMasterDetailPageViewModel : BindableBase
+    {
+        public PrismPopupMasterDetailPageViewModel(INavigationService navigationService)
+        {
+			_navigationService = navigationService;
+			NavigateToLTR_RTLPageCommand = new DelegateCommand<string>(GoToDetailPage, CanGoToDetailPage);
+		}
+
+		#region Properties
+
+		public INavigationService _navigationService { get; set; }
+
+		#endregion
+
+		#region DelegateComands
+
+		#region NavigateToLTR_RTLPageCommand
+		public DelegateCommand<string> NavigateToLTR_RTLPageCommand { get; private set; }
+
+		async void GoToDetailPage(string detailPageName)
+		{
+			//implement logic
+			try
+			{
+				await _navigationService.NavigateAsync($"/PrismPopupMasterDetailPage/NavigationPage/{detailPageName}");
+			}
+			catch (Exception ex)
+			{
+#if DEBUG
+				Debug.WriteLine("Error occurred during navigation " + ex.Message);
+#endif
+				throw;
+			}
+		}
+
+		bool CanGoToDetailPage(string detailPageName)
+		{
+			return true;
+		}
+
+		#endregion
+
+
+
+		#endregion
+	}
+}

--- a/PrismPopup/PrismPopup/PrismPopup/Views/PrismPopupMasterDetailPage.xaml
+++ b/PrismPopup/PrismPopup/PrismPopup/Views/PrismPopupMasterDetailPage.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<MasterDetailPage x:Class="PrismPopup.Views.PrismPopupMasterDetailPage"
+                  xmlns="http://xamarin.com/schemas/2014/forms"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                  xmlns:prism="http://prismlibrary.com"
+                  prism:ViewModelLocator.AutowireViewModel="True">
+
+    <MasterDetailPage.Master>
+        <ContentPage Title="Menu">
+            <StackLayout Padding="20">
+                <!--  TODO: // Update the Layout and add some real menu items  -->
+                <!--<Button Text="ViewA" Command="{Binding NavigateCommand}" CommandParameter="ViewA" />-->
+
+                <Button x:Name="LTRButton"
+                        Clicked="LTRButton_Clicked"
+                        Text="English" />
+
+                <Button x:Name="RTLButton"
+                        Clicked="RTLButton_Clicked"
+                        Text="Arabic" />
+
+                <!--<Button x:Name="NavigateToMainPageButton"
+                        Clicked="NavigateToMainPageButton_Clicked"
+                        Text="Navigate"/>-->
+
+                <Label x:Name="NavigateToMainPageButton" Text="NavigateTo_LTR-RTL_Page">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding Path=BindingContext.NavigateToLTR_RTLPageCommand, Source={x:Reference NavigateToMainPageButton}}"
+                                              CommandParameter="MainPage"
+                                              NumberOfTapsRequired="1" />
+                    </Label.GestureRecognizers>
+                </Label>
+
+            </StackLayout>
+        </ContentPage>
+    </MasterDetailPage.Master>
+
+</MasterDetailPage>

--- a/PrismPopup/PrismPopup/PrismPopup/Views/PrismPopupMasterDetailPage.xaml.cs
+++ b/PrismPopup/PrismPopup/PrismPopup/Views/PrismPopupMasterDetailPage.xaml.cs
@@ -1,0 +1,31 @@
+﻿using PrismPopup.Helpers;
+using Xamarin.Forms;
+
+namespace PrismPopup.Views
+{
+    public partial class PrismPopupMasterDetailPage : MasterDetailPage
+    {
+        private const string LTRLanguage = "en-US";
+        private const string RTLLanguage = "ar";
+
+        public PrismPopupMasterDetailPage()
+        {
+            InitializeComponent();
+        }
+
+        private void LTRButton_Clicked(object sender, System.EventArgs e)
+        {
+            CultureService.SetCultureForLanguage(LTRLanguage);
+        }
+
+        private void RTLButton_Clicked(object sender, System.EventArgs e)
+        {
+            CultureService.SetCultureForLanguage(RTLLanguage);
+        }
+
+        private async void NavigateToMainPageButton_Clicked(object sender, System.EventArgs e)
+        {
+            await Navigation.PushAsync(new MainPage());
+        }
+    }
+}

--- a/PrismPopup/PrismPopup/PrismPopup/Views/templates/CultureChangePopup.xaml.cs
+++ b/PrismPopup/PrismPopup/PrismPopup/Views/templates/CultureChangePopup.xaml.cs
@@ -16,6 +16,11 @@ namespace PrismPopup.Views.templates
     {
         public void TapGestureRecognizer_Tapped(object sender, EventArgs e)
         {
+            //await Task.Delay(400);
+            //if (Application.Current.MainPage.Navigation.NavigationStack.Last() is MainPage)
+            //{
+            //    popup.Show();
+            //}
             popup.Show();            
         }
 


### PR DESCRIPTION
Added PrismPopupMasterDetailPage.xaml to show the suggested solution doesn't work for TapGestureNavigation.

Please check the TapGestureRecognizer_Tapped in CultureChangePopup class.
The issue still occurs with and without the suggested solution.

The solution is really required at the iOS renderer level.

Thank you.